### PR TITLE
Add safeguards, POSIX sh-compliance, and aesthetic tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # adblocker
-A bash script that uses /etc/hosts to block advertising/malicious/tracking domains
+A shell script that uses /etc/hosts to block advertising/malicious/tracking domains
 
 ___
 
@@ -19,9 +19,9 @@ In short, adblocker takes these steps to block unwanted domains via the /etc/hos
   4. wgets [StevenBlack's filter](https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts)
   6. adds block filter for reddit tracking domains
   7. replaces the **/etc/hosts** file with the new one
-  8. deletes the tmp directory
-  
-This is all achived in 23 lines of commented and formatted code.
+  8. deletes the /tmp/adblocker/ directory
+
+This is all achieved in 34 lines of commented and formatted code.
 
 ___
 
@@ -36,13 +36,13 @@ The are various ways to automate the execution of this script:
 
 1) Creating a cron job will allow the script to automatically run ever hour/day/week/etc.
 
-2) Creating a bashrc alias will allow you to maually execute the script more easily.
+2) Creating a bashrc alias will allow you to manually execute the script more easily.
 
 ##### Cron Job
 Use this command:
 
   ```$ sudo cp /path/to/adblocker.sh /etc/cron.weekly/adblocker.sh```
-  
+
 Change the *.weekly* to a time of your choice - *.daily* | *.hourly* | *.weekly* | *.monthly*
 
 ##### Bashrc Alias
@@ -62,19 +62,19 @@ The MIT License (MIT)
 
 Copyright (c) 2016 Phillip T.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-associated documentation files (the "Software"), to deal in the Software without restriction, including 
-without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
 following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial 
+The above copyright notice and this permission notice shall be included in all copies or substantial
 portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
-LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO 
-EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
 THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In short, adblocker takes these steps to block unwanted domains via the /etc/hos
   4. wgets [StevenBlack's filter](https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts)
   6. adds block filter for reddit tracking domains
   7. replaces the **/etc/hosts** file with the new one
-  8. deletes the /tmp/adblocker/ directory
+  8. deletes the **/tmp/adblocker/** directory
 
 This is all achieved in 34 lines of commented and formatted code.
 

--- a/adblocker/adblocker.sh
+++ b/adblocker/adblocker.sh
@@ -1,13 +1,23 @@
-#!/bin/bash
+#!/bin/sh
 
 ############################
+
+fail() {
+	echo "$1" >&2 # print error message to stderr
+	exit 1 # exit with non-success
+}
+
+# check if script is being run by root or with sudo / if not, fail
+if [ ! "$(id -u)" -eq 0 ]; then
+	fail "This must be run as root. Do 'sudo !!' to try again."
+fi
 
 # check if backup exists | if not, backup hosts file
 [ ! -e /etc/hosts.bk ] && cp /etc/hosts /etc/hosts.bk
 
-# create tmp directory + cd into directory
-mkdir /tmp/adblocker/
-cd /tmp/adblocker/
+# create tmp directory + cd into directory if possible
+[ ! -e /tmp/adblocker ] && mkdir /tmp/adblocker
+cd /tmp/adblocker || fail "Couldn't access temp directory."
 
 # wget filters
 wget https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
@@ -20,4 +30,4 @@ echo "0.0.0.0  out.reddit.com" >> hosts
 cp /tmp/adblocker/hosts /etc/hosts
 
 # cleanup
-rm -rf /tmp/adblocker
+rm -r /tmp/adblocker

--- a/adblocker/adblocker.sh
+++ b/adblocker/adblocker.sh
@@ -23,8 +23,8 @@ cd /tmp/adblocker || fail "Couldn't access temp directory."
 wget https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
 
 # block reddit tracking
-echo "0.0.0.0  events.redditmedia.com" >> hosts
-echo "0.0.0.0  out.reddit.com" >> hosts
+echo "0.0.0.0 events.redditmedia.com" >> hosts
+echo "0.0.0.0 out.reddit.com" >> hosts
 
 # replace host file
 cp /tmp/adblocker/hosts /etc/hosts


### PR DESCRIPTION
The script is no longer Bash-only (as indicated by the shebang) as the script should already work in any POSIX-compliant shell.

New safeguards have been added to warn the user if they fail to run the script as root, as well as to exit with a non-zero error status if certain actions (e.g. `cd`) fail.

The README has been updated, and some minor spelling/Markdown tweaks have been made.
